### PR TITLE
feat:Add dynamic mode switching for MCP control block

### DIFF
--- a/ai-vox-xzai/block.json
+++ b/ai-vox-xzai/block.json
@@ -959,29 +959,17 @@
         "type": "esp32ai_selget_mcp_control",
         "args0": [
             {
-                "type": "field_variable", 
+                "type": "field_variable",
                 "name": "VAR",
                 "variable": "led",
                 "variableTypes": ["AIVOX"],
                 "defaultType": "AIVOX"
             }
         ],
-        "message1": "设置 %1",
-        "args1": [
-            {
-                "type": "input_statement",
-                "name": "setCODE_BLOCK"
-            }
-        ],
-        "message2": "上报 %1",
-        "args2": [
-            {
-                "type": "input_statement",
-                "name": "CODE_BLOCK"
-            }
-        ],
         "previousStatement": null,
         "nextStatement": null,
-        "colour": "#2196F3"
+        "colour": "#2196F3",
+        "mutator": "esp32ai_selget_mcp_control_mutator",
+        "extensions": ["esp32ai_selget_mcp_control_extension"]
     }
 ]

--- a/ai-vox-xzai/package.json
+++ b/ai-vox-xzai/package.json
@@ -1,36 +1,36 @@
 {
-    "name": "@aily-project/lib-esp32-xzai",
-    "nickname": "小智AI",
-    "author": "笨笨熊",
-    "description": "Arduino版小智AI，基于AI Vox语音交互引擎支持库，适用于ESP32、ESP32S3开发板。",
-    "version": "0.0.2",
-    "url": "https://dcnmu33qx4fc.feishu.cn/docx/Lpy7dfEYAo04PzxJNI0ceTj5nxg",
-    "compatibility": {
-        "core": [
-            "esp32:esp32",
-            "esp32:esp32s3"
-        ],
-        "voltage": [
-            3.3
-        ]
-    },
-    "keywords": [
-        "aily",
-        "blockly",
-        "esp32",
-        "esp32s3",
-        "小智AI",
-        "aivox",
-        "AI",
-        "voice",
-        "speech",
-        "语音交互",
-        "语音识别",
-        "esp32-xzai"
+  "name": "@aily-project/lib-esp32-xzai",
+  "nickname": "小智AI",
+  "author": "笨笨熊",
+  "description": "Arduino版小智AI，基于AI Vox语音交互引擎支持库，适用于ESP32、ESP32S3开发板。",
+  "version": "0.0.3",
+  "url": "https://dcnmu33qx4fc.feishu.cn/docx/Lpy7dfEYAo04PzxJNI0ceTj5nxg",
+  "compatibility": {
+    "core": [
+      "esp32:esp32",
+      "esp32:esp32s3"
     ],
-    "scripts": {},
-    "dependencies": {},
-    "devDependencies": {},
-    "tester": "笨笨熊",
-    "tested": true
+    "voltage": [
+      3.3
+    ]
+  },
+  "keywords": [
+    "aily",
+    "blockly",
+    "esp32",
+    "esp32s3",
+    "小智AI",
+    "aivox",
+    "AI",
+    "voice",
+    "speech",
+    "语音交互",
+    "语音识别",
+    "esp32-xzai"
+  ],
+  "scripts": {},
+  "dependencies": {},
+  "devDependencies": {},
+  "tester": "笨笨熊",
+  "tested": true
 }


### PR DESCRIPTION
Implement mutator and extension for the `esp32ai_selget_mcp_control` block to dynamically adjust input fields based on the selected mode. Update block JSON to include mutator and extension references, and modify generator to handle conditional input presence. Bump version to 0.0.3 in package.json.