### PR TITLE
Update library: @aily-project/lib-unihiker-k10-button to 0.3.0

### DIFF
--- a/unihiker_k10_button/generator.js
+++ b/unihiker_k10_button/generator.js
@@ -1,6 +1,7 @@
 // Ensure k10 object is initialized
 function ensureK10(generator) {
-  generator.addLibrary('unihiker_k10', '#include "unihiker_k10.h"');
+  generator.addLibrary('SPIFFS', '#include <SPIFFS.h>');
+  generator.addLibrary('unihiker_k10', '#include <unihiker_k10.h>');
   generator.addVariable('k10', 'UNIHIKER_K10 k10;');
   generator.addSetupBegin('k10_begin', 'k10.begin();');
 }

--- a/unihiker_k10_button/package.json
+++ b/unihiker_k10_button/package.json
@@ -7,7 +7,7 @@
   "description": "UNIHIKER K10板载按键库，支持A/B/AB按键轮询和中断回调",
   "description_zh_cn": "UNIHIKER K10板载按键库，支持A/B/AB按键轮询和中断回调",
   "description_en": "UNIHIKER K10 onboard button library, supports A/B/AB button polling and interrupt callbacks",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "compatibility": {
     "core": [
       "UNIHIKER:esp32:k10"


### PR DESCRIPTION
## 修复了什么
- 修复生成代码的 K10 头文件引用，改为 <unihiker_k10.h>。
- 补充 SPIFFS 头文件依赖，避免 K10 SDK 相关编译缺失。
- 版本更新到 0.3.0。

## 验证
- 已运行: `node .scripts_git_action/validate-library-compliance.js unihiker_k10_button`

## 变更范围
- `unihiker_k10_button/generator.js`
- `unihiker_k10_button/package.json`