### PR TITLE
Update library: @aily-project/lib-unihiker-k10-display to 0.3.0

### DIFF
--- a/unihiker_k10_display/generator.js
+++ b/unihiker_k10_display/generator.js
@@ -8,7 +8,8 @@ function colorToHex(color) {
 
 // Ensure k10 object is initialized (begin only).
 function ensureK10(generator) {
-  generator.addLibrary('unihiker_k10', '#include "unihiker_k10.h"');
+  generator.addLibrary('SPIFFS', '#include <SPIFFS.h>');
+  generator.addLibrary('unihiker_k10', '#include <unihiker_k10.h>');
   generator.addVariable('k10', 'UNIHIKER_K10 k10;');
   generator.addSetupBegin('k10_begin', 'k10.begin();');
 }

--- a/unihiker_k10_display/package.json
+++ b/unihiker_k10_display/package.json
@@ -7,7 +7,7 @@
   "description": "UNIHIKER K10屏幕显示库，支持绘制点、线、圆、矩形、文字、图片和二维码",
   "description_zh_cn": "UNIHIKER K10屏幕显示库，支持绘制点、线、圆、矩形、文字、图片和二维码",
   "description_en": "UNIHIKER K10 screen display library, supports drawing points, lines, circles, rectangles, text, images and QR codes",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "compatibility": {
     "core": [
       "UNIHIKER:esp32:k10"


### PR DESCRIPTION
## 修复了什么
- 修复生成代码的 K10 头文件引用，改为 <unihiker_k10.h>。
- 补充 SPIFFS 头文件依赖，避免显示/图片相关功能编译缺失。
- 版本更新到 0.3.0。

## 验证
- 已运行: `node .scripts_git_action/validate-library-compliance.js unihiker_k10_display`

## 变更范围
- `branch 'codex/submit-unihiker-k10-display-0.3.0-20260709-215412' set up to track 'upstream/main'.`
- `HEAD is now at cec25b03 调整检查脚本`
- `Staged files for unihiker_k10_display: unihiker_k10_display/generator.js, unihiker_k10_display/package.json`
- `📋 已加载配置文件: D:\Github\Aily\aily-blockly-libraries\.github\compliance-config.yml`
- ``
- ``
- `🔍 检测库: unihiker_k10_display`
- `==================================================`
- ``
- `📁 检测文件结构...`
- `  ✅ block.json`
- `  ✅ generator.js`
- `  ✅ toolbox.json`
- `  ✅ package.json`
- `  ✅ README.md`
- ``
- `📄 检测JSON格式...`
- `  ✅ block.json 格式正确`
- `  ✅ toolbox.json 格式正确`
- `  ✅ package.json 格式正确`
- ``
- `📦 检测package.json规范...`
- `  ✅ name 字段存在`
- `  ✅ version 字段存在`
- `  ✅ description 字段存在`
- `  ✅ compatibility 字段存在`
- `  ✅ 命名规范正确`
- `  ✅ 版本号格式正确`
- `  ✅ compatibility.core 配置存在`
- ``
- `🧩 检测block.json设计规范...`
- `  📊 共发现 15 个块定义`
- `  ✅ k10_init_screen: 包含tooltip说明`
- `  ✅ k10_set_background: 包含tooltip说明`
- `  ✅ k10_draw_point: 包含tooltip说明`
- `  ✅ k10_draw_line: 包含tooltip说明`
- `  ✅ k10_set_line_width: 包含tooltip说明`
- `  ✅ k10_draw_circle: 包含tooltip说明`
- `  ✅ k10_draw_rectangle: 包含tooltip说明`
- `  ✅ k10_draw_text_simple: 包含tooltip说明`
- `  ✅ k10_draw_text: 包含tooltip说明`
- `  ✅ k10_draw_bitmap: 包含tooltip说明`
- `  ✅ k10_draw_image: 包含tooltip说明`
- `  ✅ k10_draw_qrcode: 包含tooltip说明`
- `  ✅ k10_update_canvas: 包含tooltip说明`
- `  ✅ k10_clear_canvas: 包含tooltip说明`
- `  ✅ k10_screen_size: 值块设计正确`
- `  ✅ k10_screen_size: 值块连接属性正确`
- `  ✅ k10_screen_size: 包含tooltip说明`
- `  📈 块类型统计: 初始化(1) 方法调用(13) Hat块(0) 值块(1) 全局对象(0) 快速操作(0)`
- `  ✅ 包含初始化块，结构合理`
- ``
- `🧰 检测toolbox.json规范...`
- `  📊 发现 9 个需要影子块的块`
- `  ✅ k10_draw_point: 配置了影子块 (X, Y)`
- `  ✅ k10_draw_line: 配置了影子块 (X1, Y1, X2, Y2)`
- `  ✅ k10_draw_circle: 配置了影子块 (X, Y, R)`
- `  ✅ k10_draw_rectangle: 配置了影子块 (X, Y, W, H)`
- `  ✅ k10_draw_text_simple: 配置了影子块 (TEXT)`
- `  ✅ k10_draw_text: 配置了影子块 (TEXT, X, Y)`
- `  ✅ k10_draw_bitmap: 配置了影子块 (X, Y, W, H)`
- `  ✅ k10_draw_image: 配置了影子块 (PATH, X, Y)`
- `  ✅ k10_draw_qrcode: 配置了影子块 (CONTENT)`
- ``
- `📚 检测README规范...`
- `  ✅ readme.md 符合人类文档规范`
- `  ✅ readme_ai.md 符合ABS参考规范`
- ``
- `⚙️  检测generator.js最佳实践...`
- `  ⚠️  缺少核心库函数: registerVariableToBlockly`
- `  ⚠️  缺少核心库函数: renameVariableInBlockly`
- `  ⚠️  缺少变量重命名监听机制`
- `  💡 建议: 实现板卡适配机制`
- `  ✅ 实现库重复检测机制`
- `  💡 建议: 确保Serial初始化`
- ``
- `📊 检测报告`
- `==============================`
- `📈 综合评分: 49/54 (91%)`
- ``
- `❗ 发现 5 个问题:`
- ``
- `📁 generator.js:`
- `  ⚠️ 未使用核心库函数: registerVariableToBlockly`
- `     💡 建议: 使用 registerVariableToBlockly 函数管理变量`
- `  ⚠️ 未使用核心库函数: renameVariableInBlockly`
- `     💡 建议: 使用 renameVariableInBlockly 函数管理变量`
- `  ⚠️ 缺少变量重命名监听机制`
- `     💡 建议: 实现field validator监听变量名变化`
- `  ⚠️ 建议实现板卡适配机制`
- `     💡 建议: 根据boardConfig适配不同开发板的库`
- `  ⚠️ 建议确保Serial初始化`
- `     💡 建议: 在需要输出调试信息时确保Serial.begin`
- ``
- `============================================================`
- `🔁 工作区级检测`
- `============================================================`
- ``
- `🔁 检测重复的包名...`
- `  ✅ 未发现重复的包名`
- `[codex/submit-unihiker-k10-display-0.3.0-20260709-215412 a77cc369] Update library: @aily-project/lib-unihiker-k10-display to 0.3.0`
- ` 2 files changed, 3 insertions(+), 2 deletions(-)`
- `unihiker_k10_display/generator.js`
- `unihiker_k10_display/package.json`