### PR TITLE
Update library: @aily-project/lib-unihiker-k10-speech to 0.2.0

### DIFF
--- a/unihiker_k10_speech/generator.js
+++ b/unihiker_k10_speech/generator.js
@@ -1,20 +1,43 @@
 function ensureK10(generator) {
-  generator.addLibrary('unihiker_k10', '#include "unihiker_k10.h"');
+  generator.addLibrary('SPIFFS', '#include <SPIFFS.h>');
+  generator.addLibrary('unihiker_k10', '#include <unihiker_k10.h>');
   generator.addVariable('k10', 'UNIHIKER_K10 k10;');
   generator.addSetupBegin('k10_begin', 'k10.begin();');
 }
 
 function ensureASR(generator) {
   ensureK10(generator);
-  generator.addLibrary('asr', '#include "asr.h"');
+  generator.addLibrary('asr', '#include <asr.h>');
   generator.addVariable('asr', 'ASR asr;');
+}
+
+function ensureASRStarted(generator) {
+  ensureASR(generator);
+  generator.addSetupBegin('asr_init', 'asr.asrInit(CONTINUOUS, CN_MODE, 6000);');
+  generator.addSetupBegin('asr_wait', 'while(asr._asrState == 0){delay(100);}');
+}
+
+function ensureTTS(generator) {
+  ensureASRStarted(generator);
+  generator.addSetupBegin('asr_tts_init', 'asr.setAsrSpeed(3);');
+  generator.addFunction('k10_asr_speak_safe', `void k10AsrSpeakSafe(ASR &asrObj, String text) {
+  static uint32_t lastSpeakTime = 0;
+  uint32_t now = millis();
+  if (lastSpeakTime != 0 && (uint32_t)(now - lastSpeakTime) < 1500) {
+    return;
+  }
+  if (now < 1000) {
+    delay(1000 - now);
+  }
+  lastSpeakTime = millis();
+  asrObj.speak(text);
+}
+`);
 }
 
 // ========== 初始化语音识别 ==========
 Arduino.forBlock['k10_asr_init'] = function(block, generator) {
-  ensureASR(generator);
-  generator.addSetupBegin('asr_init', 'asr.asrInit(CONTINUOUS, ZH, 10);');
-  generator.addSetupBegin('asr_wait', 'while(asr._asrState == 0){delay(100);}');
+  ensureASRStarted(generator);
   return '';
 };
 
@@ -22,33 +45,33 @@ Arduino.forBlock['k10_asr_init'] = function(block, generator) {
 Arduino.forBlock['k10_asr_add_command'] = function(block, generator) {
   var id = generator.valueToCode(block, 'ID', generator.ORDER_ATOMIC) || '0';
   var keyword = generator.valueToCode(block, 'KEYWORD', generator.ORDER_ATOMIC) || '""';
-  ensureASR(generator);
+  ensureASRStarted(generator);
   return 'asr.addASRCommand(' + id + ', ' + keyword + ');\n';
 };
 
 // ========== 语音是否唤醒 ==========
 Arduino.forBlock['k10_asr_is_wakeup'] = function(block, generator) {
-  ensureASR(generator);
+  ensureASRStarted(generator);
   return ['asr.isWakeUp()', generator.ORDER_ATOMIC];
 };
 
 // ========== 识别到命令 ==========
 Arduino.forBlock['k10_asr_is_detected'] = function(block, generator) {
   var id = generator.valueToCode(block, 'ID', generator.ORDER_ATOMIC) || '0';
-  ensureASR(generator);
+  ensureASRStarted(generator);
   return ['asr.isDetectCmdID(' + id + ')', generator.ORDER_ATOMIC];
 };
 
 // ========== 语音合成播报 ==========
 Arduino.forBlock['k10_asr_speak'] = function(block, generator) {
   var text = generator.valueToCode(block, 'TEXT', generator.ORDER_ATOMIC) || '""';
-  ensureASR(generator);
-  return 'asr.speak(' + text + ');\n';
+  ensureTTS(generator);
+  return 'k10AsrSpeakSafe(asr, ' + text + ');\n';
 };
 
 // ========== 设置播报速度 ==========
 Arduino.forBlock['k10_asr_set_speed'] = function(block, generator) {
   var speed = block.getFieldValue('SPEED');
-  ensureASR(generator);
+  ensureASRStarted(generator);
   return 'asr.setAsrSpeed(' + speed + ');\n';
 };

--- a/unihiker_k10_speech/package.json
+++ b/unihiker_k10_speech/package.json
@@ -7,7 +7,7 @@
   "description": "UNIHIKER K10语音识别与合成库，支持中英文语音识别、命令词检测和语音合成播报",
   "description_zh_cn": "UNIHIKER K10语音识别与合成库，支持中英文语音识别、命令词检测和语音合成播报",
   "description_en": "UNIHIKER K10 speech recognition and synthesis library, supports Chinese/English speech recognition, command detection and TTS",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "compatibility": {
     "core": [
       "UNIHIKER:esp32:k10"

--- a/unihiker_k10_speech/readme.md
+++ b/unihiker_k10_speech/readme.md
@@ -1,6 +1,6 @@
 # K10 Speech Recognition & Synthesis
 
-UNIHIKER K10 speech recognition and synthesis library, supports Chinese/English speech recognition, command detection and TTS
+UNIHIKER K10 speech recognition and synthesis library, supports Chinese/English speech recognition, command detection and TTS. The speak block automatically initializes TTS with the slow default speed and guards rapid repeated playback.
 
 ## Library Info
 
@@ -18,7 +18,7 @@ UNIHIKER:esp32:k10
 
 ## Description
 
-UNIHIKER K10 speech recognition and synthesis library, supports Chinese/English speech recognition, command detection and TTS
+UNIHIKER K10 speech recognition and synthesis library, supports Chinese/English speech recognition, command detection and TTS. The speak block automatically initializes TTS with the slow default speed and guards rapid repeated playback.
 
 ## Quick Start
 

--- a/unihiker_k10_speech/readme_ai.md
+++ b/unihiker_k10_speech/readme_ai.md
@@ -10,11 +10,11 @@ UNIHIKER K10 speech recognition and synthesis library, supports Chinese/English 
 
 | Block Type | Connection | Parameters (args0 order) | ABS Format | Generated Code |
 |------------|------------|--------------------------|------------|----------------|
-| `k10_asr_init` | Statement | (none) | `k10_asr_init()` | Dynamic code |
+| `k10_asr_init` | Statement | (none) | `k10_asr_init()` | `asr.asrInit(CONTINUOUS, CN_MODE, 6000)` plus wait until ASR is ready |
 | `k10_asr_add_command` | Statement | ID(input_value), KEYWORD(input_value) | `k10_asr_add_command(math_number(0), text("value"))` | asr.addASRCommand( |
 | `k10_asr_is_wakeup` | Value | (none) | `k10_asr_is_wakeup()` | asr.isWakeUp() |
 | `k10_asr_is_detected` | Value | ID(input_value) | `k10_asr_is_detected(math_number(0))` | asr.isDetectCmdID( |
-| `k10_asr_speak` | Statement | TEXT(input_value) | `k10_asr_speak(text("value"))` | asr.speak( |
+| `k10_asr_speak` | Statement | TEXT(input_value) | `k10_asr_speak(text("value"))` | `k10AsrSpeakSafe(asr, text);` after default TTS init |
 | `k10_asr_set_speed` | Statement | SPEED(dropdown) | `k10_asr_set_speed("1")` | asr.setAsrSpeed( |
 
 ## Parameter Options
@@ -40,3 +40,5 @@ arduino_loop()
 
 1. **Parameter order**: ABS parameters follow `block.json` args order.
 2. **Input values**: use `math_number(n)`, `text("s")`, `logic_boolean(TRUE/FALSE)`, variables, or nested value blocks.
+3. **TTS initialization**: `k10_asr_speak` automatically emits `asr.setAsrSpeed(3);` during setup before speaking, using the library's "slow" speed as the default because the K10 SDK uses this call to initialize TTS.
+4. **Repeated playback guard**: `k10_asr_speak` emits `k10AsrSpeakSafe(...)`, which ignores calls closer than 1500 ms to avoid overwhelming the K10 audio task when a speak block is placed in a fast loop.


### PR DESCRIPTION
## 修复了什么
- 修复 ASR/TTS 头文件引用与 K10/SPIFFS 依赖。
- 将 ASR 初始化改为 CN_MODE/6000，并增加 ensureASRStarted 复用初始化流程。
- 添加安全播报 helper，自动初始化 TTS 速度并限制过快重复 speak，版本更新到 0.2.0。

## 验证
- 已运行: `node .scripts_git_action/validate-library-compliance.js unihiker_k10_speech`

## 变更范围
- `branch 'codex/submit-unihiker-k10-speech-0.2.0-20260709-215412' set up to track 'upstream/main'.`
- `HEAD is now at cec25b03 调整检查脚本`
- `Staged files for unihiker_k10_speech: unihiker_k10_speech/generator.js, unihiker_k10_speech/package.json, unihiker_k10_speech/readme.md, unihiker_k10_speech/readme_ai.md`
- `📋 已加载配置文件: D:\Github\Aily\aily-blockly-libraries\.github\compliance-config.yml`
- ``
- ``
- `🔍 检测库: unihiker_k10_speech`
- `==================================================`
- ``
- `📁 检测文件结构...`
- `  ✅ block.json`
- `  ✅ generator.js`
- `  ✅ toolbox.json`
- `  ✅ package.json`
- `  ✅ README.md`
- ``
- `📄 检测JSON格式...`
- `  ✅ block.json 格式正确`
- `  ✅ toolbox.json 格式正确`
- `  ✅ package.json 格式正确`
- ``
- `📦 检测package.json规范...`
- `  ✅ name 字段存在`
- `  ✅ version 字段存在`
- `  ✅ description 字段存在`
- `  ✅ compatibility 字段存在`
- `  ✅ 命名规范正确`
- `  ✅ 版本号格式正确`
- `  ✅ compatibility.core 配置存在`
- ``
- `🧩 检测block.json设计规范...`
- `  📊 共发现 6 个块定义`
- `  ✅ k10_asr_init: 包含tooltip说明`
- `  ✅ k10_asr_add_command: 包含tooltip说明`
- `  ✅ k10_asr_is_wakeup: 值块设计正确`
- `  ✅ k10_asr_is_wakeup: 值块连接属性正确`
- `  ✅ k10_asr_is_wakeup: 包含tooltip说明`
- `  ✅ k10_asr_is_detected: 值块设计正确`
- `  ✅ k10_asr_is_detected: 值块连接属性正确`
- `  ✅ k10_asr_is_detected: 包含tooltip说明`
- `  ✅ k10_asr_speak: 包含tooltip说明`
- `  ✅ k10_asr_set_speed: 包含tooltip说明`
- `  📈 块类型统计: 初始化(1) 方法调用(3) Hat块(0) 值块(2) 全局对象(0) 快速操作(0)`
- `  ✅ 包含初始化块，结构合理`
- ``
- `🧰 检测toolbox.json规范...`
- `  📊 发现 3 个需要影子块的块`
- `  ✅ k10_asr_add_command: 配置了影子块 (ID, KEYWORD)`
- `  ✅ k10_asr_is_detected: 配置了影子块 (ID)`
- `  ✅ k10_asr_speak: 配置了影子块 (TEXT)`
- ``
- `📚 检测README规范...`
- `  ✅ readme.md 符合人类文档规范`
- `  ✅ readme_ai.md 符合ABS参考规范`
- ``
- `⚙️  检测generator.js最佳实践...`
- `  ⚠️  缺少核心库函数: registerVariableToBlockly`
- `  ⚠️  缺少核心库函数: renameVariableInBlockly`
- `  ⚠️  缺少变量重命名监听机制`
- `  ✅ 使用addFunction添加函数定义`
- `  💡 建议: 实现板卡适配机制`
- `  ✅ 实现库重复检测机制`
- `  💡 建议: 确保Serial初始化`
- ``
- `📊 检测报告`
- `==============================`
- `📈 综合评分: 37/42 (88%)`
- ``
- `❗ 发现 5 个问题:`
- ``
- `📁 generator.js:`
- `  ⚠️ 未使用核心库函数: registerVariableToBlockly`
- `     💡 建议: 使用 registerVariableToBlockly 函数管理变量`
- `  ⚠️ 未使用核心库函数: renameVariableInBlockly`
- `     💡 建议: 使用 renameVariableInBlockly 函数管理变量`
- `  ⚠️ 缺少变量重命名监听机制`
- `     💡 建议: 实现field validator监听变量名变化`
- `  ⚠️ 建议实现板卡适配机制`
- `     💡 建议: 根据boardConfig适配不同开发板的库`
- `  ⚠️ 建议确保Serial初始化`
- `     💡 建议: 在需要输出调试信息时确保Serial.begin`
- ``
- `============================================================`
- `🔁 工作区级检测`
- `============================================================`
- ``
- `🔁 检测重复的包名...`
- `  ✅ 未发现重复的包名`
- `[codex/submit-unihiker-k10-speech-0.2.0-20260709-215412 34ca37e7] Update library: @aily-project/lib-unihiker-k10-speech to 0.2.0`
- ` 4 files changed, 41 insertions(+), 16 deletions(-)`
- `unihiker_k10_speech/generator.js`
- `unihiker_k10_speech/package.json`
- `unihiker_k10_speech/readme.md`
- `unihiker_k10_speech/readme_ai.md`