### PR TITLE
Optimize Qwen K10 multimodal audio playback

### DIFF
--- a/qwen-omni/generator.js
+++ b/qwen-omni/generator.js
@@ -18,6 +18,7 @@ function ensureQwenOmniPlaybackHelpers(generator) {
   generator.addVariable('qwen_playback_total_played', 'volatile size_t qwen_playback_total_played = 0;');
   generator.addVariable('qwen_playback_started', 'bool qwen_playback_started = false;');
   generator.addVariable('qwen_playback_buffered', 'size_t qwen_playback_buffered = 0;');
+  generator.addVariable('qwen_playback_underruns', 'volatile uint32_t qwen_playback_underruns = 0;');
   generator.addVariable('qwen_playback_sample_rate', 'uint32_t qwen_playback_sample_rate = 24000;');
   generator.addVariable('qwen_playback_bits_per_sample', 'uint16_t qwen_playback_bits_per_sample = 16;');
   generator.addVariable('qwen_playback_channels', 'uint16_t qwen_playback_channels = 1;');
@@ -44,8 +45,8 @@ size_t qwen_base64_encoded_len(size_t len) {
 
   generator.addFunction('qwen_stream_playback_helpers', String.raw`
 #define QWEN_PLAYBACK_BUFFER_SIZE 196608
-#define QWEN_PLAYBACK_PREBUFFER_SIZE 48000
-#define QWEN_PLAYBACK_CHUNK_SIZE 2048
+#define QWEN_PLAYBACK_PREBUFFER_SIZE 32768
+#define QWEN_PLAYBACK_CHUNK_SIZE 4096
 #define QWEN_DECODE_BUF_SIZE 16384
 
 bool qwen_i2s_prepare_es8311_playback(I2SClass &i2s, uint32_t sampleRate, i2s_data_bit_width_t bitWidth, i2s_slot_mode_t slotMode);
@@ -108,6 +109,7 @@ void qwen_playback_task_entry(void* param) {
   while (!qwen_playback_done || xStreamBufferBytesAvailable(qwen_playback_stream) > 0) {
     size_t n = xStreamBufferReceive(qwen_playback_stream, chunk, sizeof(chunk), pdMS_TO_TICKS(20));
     if (n == 0) {
+      if (!qwen_playback_done) qwen_playback_underruns++;
       delay(1);
       continue;
     }
@@ -139,6 +141,7 @@ bool qwen_prepare_stream_playback(I2SClass &i2s) {
   qwen_playback_total_played = 0;
   qwen_playback_started = false;
   qwen_playback_buffered = 0;
+  qwen_playback_underruns = 0;
   qwen_playback_sample_rate = 24000;
   qwen_playback_bits_per_sample = 16;
   qwen_playback_channels = 1;
@@ -181,8 +184,8 @@ bool qwen_start_stream_playback() {
   }
   Serial.println("[QWEN-AUDIO] playback start: " + String(qwen_playback_sample_rate) + "Hz " + String(qwen_playback_bits_per_sample) + "bit " + String(qwen_playback_channels) + "ch");
 
-  BaseType_t taskOk = xTaskCreate(
-    qwen_playback_task_entry, "qwen_tts_play", 4096, NULL, 3, &qwen_playback_task_handle);
+  BaseType_t taskOk = xTaskCreatePinnedToCore(
+    qwen_playback_task_entry, "qwen_tts_play", 12288, NULL, 6, &qwen_playback_task_handle, ARDUINO_RUNNING_CORE);
   if (taskOk != pdPASS) {
     qwen_playback_task_handle = NULL;
     Serial.println("[QWEN-AUDIO] playback task create failed");
@@ -459,7 +462,10 @@ size_t qwen_stream_http_audio_to_i2s(HTTPClient &http, I2SClass &i2s, String *fu
 
   free(decodeBuf);
   size_t played = qwen_finish_stream_playback();
-  Serial.println(String("[") + tag + "] audio chunks: " + String(qwen_audio_stream_chunks) + ", queued: " + String(queuedAudio) + ", played: " + String(played));
+  Serial.println(String("[") + tag + "] audio chunks: " + String(qwen_audio_stream_chunks) + ", queued: " + String(queuedAudio) + ", played: " + String(played) + ", underruns: " + String(qwen_playback_underruns));
+  if (qwen_audio_stream_chunks == 0 && fullText != NULL && fullText->length() > 0) {
+    Serial.println(String("[") + tag + "] text received but no audio.data in stream");
+  }
   return played;
 }`);
 }
@@ -936,14 +942,19 @@ size_t qwen_k10_record_mono_pcm(uint8_t* pcmBuf, size_t pcmBytes, float duration
   size_t bytesRead = 0;
   unsigned long recordStart = millis();
   unsigned long maxMs = (unsigned long)(durationSeconds * 1000 + 1200);
-  int16_t stereoBuf[256];
+  uint8_t* stereoBuf = (uint8_t*)qwen_audio_alloc_buffer(6400, "k10-rec");
+  if (!stereoBuf) return 0;
+  if (xI2SMutex) xSemaphoreTake(xI2SMutex, portMAX_DELAY);
+  qwen_k10_set_amp(true);
   while (bytesRead + sizeof(int16_t) <= pcmBytes) {
     if (millis() - recordStart > maxMs) {
       Serial.println(String("[") + tag + "] K10 record timeout");
       break;
     }
     size_t got = 0;
-    esp_err_t err = i2s_read(I2S_NUM_0, stereoBuf, sizeof(stereoBuf), &got, pdMS_TO_TICKS(20));
+    size_t want = min((size_t)6400, ((pcmBytes - bytesRead) / sizeof(int16_t)) * sizeof(int16_t) * 2);
+    if (want == 0) break;
+    esp_err_t err = i2s_read(I2S_NUM_0, stereoBuf, want, &got, pdMS_TO_TICKS(250));
     if (err != ESP_OK || got < sizeof(int16_t) * 2) {
       delay(1);
       continue;
@@ -952,14 +963,19 @@ size_t qwen_k10_record_mono_pcm(uint8_t* pcmBuf, size_t pcmBytes, float duration
     int16_t* out = (int16_t*)(pcmBuf + bytesRead);
     size_t room = (pcmBytes - bytesRead) / sizeof(int16_t);
     size_t toCopy = min(pairs, room);
+    int16_t* in = (int16_t*)stereoBuf;
     for (size_t i = 0; i < toCopy; i++) {
-      int32_t left = stereoBuf[i * 2];
-      int32_t right = stereoBuf[i * 2 + 1];
+      int32_t left = in[i * 2];
+      int32_t right = in[i * 2 + 1];
       out[i] = (int16_t)((left + right) / 2);
     }
     bytesRead += toCopy * sizeof(int16_t);
   }
+  qwen_k10_set_amp(false);
+  if (xI2SMutex) xSemaphoreGive(xI2SMutex);
+  free(stereoBuf);
   if (bytesRead % sizeof(int16_t) != 0) bytesRead -= bytesRead % sizeof(int16_t);
+  Serial.println(String("[") + tag + "] K10 expected PCM bytes: " + String((size_t)(durationSeconds * 16000) * sizeof(int16_t)) + ", captured: " + String(bytesRead));
   return bytesRead;
 #else
   (void)pcmBuf;
@@ -974,14 +990,18 @@ size_t qwen_k10_write_pcm(const uint8_t* data, size_t len, uint16_t channels, ui
 #if __has_include(<unihiker_k10.h>)
   if (len == 0) return 0;
   qwen_k10_set_amp(true);
+  if (xI2SMutex) xSemaphoreTake(xI2SMutex, portMAX_DELAY);
   if (bitsPerSample == 16 && channels == 1) {
-    if (len < sizeof(int16_t)) return len;
+    if (len < sizeof(int16_t)) {
+      if (xI2SMutex) xSemaphoreGive(xI2SMutex);
+      return len;
+    }
     const int16_t* mono = (const int16_t*)data;
     size_t samples = len / sizeof(int16_t);
-    int16_t stereoBuf[256];
+    static int16_t stereoBuf[1024];
     size_t done = 0;
     while (done < samples) {
-      size_t n = min((size_t)128, samples - done);
+      size_t n = min((size_t)512, samples - done);
       for (size_t i = 0; i < n; i++) {
         int16_t v = mono[done + i];
         stereoBuf[i * 2] = v;
@@ -992,10 +1012,12 @@ size_t qwen_k10_write_pcm(const uint8_t* data, size_t len, uint16_t channels, ui
       if (written == 0) break;
       done += written / (sizeof(int16_t) * 2);
     }
+    if (xI2SMutex) xSemaphoreGive(xI2SMutex);
     return done * sizeof(int16_t);
   }
   size_t written = 0;
   i2s_write(I2S_NUM_0, data, len, &written, pdMS_TO_TICKS(200));
+  if (xI2SMutex) xSemaphoreGive(xI2SMutex);
   return written;
 #else
   (void)data;
@@ -4997,6 +5019,7 @@ void qwen_omni_voice_chat_request_v2(I2SClass &i2s, String model, String voice, 
   requestSuffix += "]}],";
   requestSuffix += "\\"modalities\\":[\\"text\\",\\"audio\\"],";
   requestSuffix += "\\"audio\\":{\\"voice\\":\\"" + voice + "\\",\\"format\\":\\"wav\\"},";
+  requestSuffix += "\\"enable_thinking\\":false,";
   requestSuffix += "\\"stream\\":true,\\"stream_options\\":{\\"include_usage\\":true}}";
 
   QwenBase64JsonStream requestStream(requestPrefix, wavBuf, wavBytes, requestSuffix);
@@ -5319,6 +5342,7 @@ void qwen_omni_voice_chat_request_dual_i2s(I2SClass &i2sMic, I2SClass &i2sSpk, S
   requestSuffix += "]}],";
   requestSuffix += "\\"modalities\\":[\\"text\\",\\"audio\\"],";
   requestSuffix += "\\"audio\\":{\\"voice\\":\\"" + voice + "\\",\\"format\\":\\"wav\\"},";
+  requestSuffix += "\\"enable_thinking\\":false,";
   requestSuffix += "\\"stream\\":true,\\"stream_options\\":{\\"include_usage\\":true}}";
 
   QwenBase64JsonStream requestStream(requestPrefix, wavBuf, wavBytes, requestSuffix);

--- a/qwen-omni/package.json
+++ b/qwen-omni/package.json
@@ -25,7 +25,7 @@
   "description_pt": "A biblioteca API de modelo de linguagem grande Alibaba Cloud Tongyi Qwen suporta diálogo de texto, diálogo multi-rodada, compreensão de imagem, geração de imagem, síntese de fala TTS, diálogo omni-modal (texto+áudio) e outras funções, e é adequada para ESP32 e outras placas de desenvolvimento habilitadas para WiFi",
   "description_ru": "Alibaba Cloud Tongyi Qwen библиотека API большой языковой модели поддерживает текстовый диалог, многораундовый диалог, понимание изображений, генерацию изображений, синтез речи TTS, омни-модальный диалог (текст+аудио) и другие функции и подходит для ESP32 и других плат разработки с поддержкой Wi-Fi.",
   "description_ar": "تدعم مكتبة Alibaba Cloud Tongyi Qwen الكبيرة لنموذج اللغة API الحوار النصي والحوار متعدد الجولات وفهم الصور وتوليد الصور وتخليق الكلام TTS والحوار متعدد الوسائط (نص+صوت) والوظائف الأخرى، وهي مناسبة لـ ESP32 ولوحات التطوير الأخرى التي تدعم WiFi",
-  "version": "0.0.10",
+  "version": "0.0.13",
   "compatibility": {
     "core": [
       "esp32:esp32:esp32",

--- a/qwen-omni/readme.md
+++ b/qwen-omni/readme.md
@@ -1,13 +1,11 @@
 # Tongyi Qianwen
 
-Alibaba Cloud Tongyi Qwen large language model API library supports text dialogue, multi-round dialogue, image understanding, image generation, TTS speech synthesis, omni-modal dialogue (text+audio) and other function...
-
 ## Library Info
 
 | Field | Value |
 |-------|-------|
 | Package | @aily-project/lib-qwen-omni |
-| Version | 0.0.10 |
+| Version | 0.0.13 |
 | Author | vonweller |
 | Source | N/A |
 | License | Original license |
@@ -18,11 +16,11 @@ ESP32, UNIHIKER K10
 
 ## Description
 
-Alibaba Cloud Tongyi Qwen large language model API library supports text dialogue, multi-round dialogue, image understanding, image generation, TTS speech synthesis, omni-modal dialogue (text+audio) and other function...
+Blocks for Alibaba Cloud Qwen text, vision, TTS, and omni-modal audio workflows.
 
 ## Quick Start
 
-1. Enable `@aily-project/lib-qwen-omni` in Aily Blockly.
-2. Add the library blocks, initialize hardware in `arduino_setup()`, then use read/write blocks in `arduino_loop()`.
-3. On UNIHIKER K10, use the K10 built-in microphone + speaker init block and select the same `i2s_k10` object for both microphone and speaker in Qwen voice chat blocks.
-4. For ES8311 + NS4150B boards, use the combined microphone + speaker init block, keep ES8311 on 3V3 and the amplifier on 5V, then run the prompt tone block before Qwen playback.
+1. Configure API key and base URL.
+2. Initialize WiFi and the needed I2S audio device.
+3. Use Qwen chat, vision, TTS, or omni voice blocks.
+4. On K10, select the same `i2s_k10` object for microphone and speaker.

--- a/qwen-omni/readme_ai.md
+++ b/qwen-omni/readme_ai.md
@@ -4,7 +4,7 @@ Alibaba Cloud Tongyi Qwen large language model API library supports text dialogu
 
 ## Library Info
 - **Name**: @aily-project/lib-qwen-omni
-- **Version**: 0.0.10
+- **Version**: 0.0.13
 
 ## Block Definitions
 
@@ -42,6 +42,7 @@ Alibaba Cloud Tongyi Qwen large language model API library supports text dialogu
 | `qwen_omni_omni_text` | Value | MESSAGE(input_value), MODEL(dropdown) | `qwen_omni_omni_text(text("value"), qwen3.5-omni-plus)` | qwen_omni_text_request("...", ...) |
 | `qwen_omni_omni_and_play` | Statement | VAR(field_variable), MESSAGE(input_value), MODEL(dropdown), VOICE(dropdown) | `qwen_omni_omni_and_play(variables_get($i2s_spk), text("value"), qwen3.5-omni-plus, Tina)` | qwen_omni_and_play_request_v3( |
 | `qwen_omni_omni_stream_play` | Statement | VAR(field_variable), MESSAGE(input_value), MODEL(dropdown), VOICE(dropdown) | `qwen_omni_omni_stream_play(variables_get($i2s_spk), text("value"), qwen3.5-omni-plus, Tina)` | qwen_omni_stream_play_request_v3( |
+| `qwen_omni_omni_record_text` | Value | MIC_VAR(field_variable), DURATION(input_value), MODEL(dropdown), PROMPT(input_value) | `qwen_omni_omni_record_text(variables_get($i2s_mic), math_number(3), qwen3.5-omni-plus, text("value"))` | qwen_omni_record_text_request( |
 | `qwen_omni_omni_get_audio` | Value | (none) | `qwen_omni_omni_get_audio()` | qwen_omni_audio_data |
 | `qwen_omni_tts_voice_design` | Statement | VAR(field_variable), TEXT(input_value), VOICE_DESC(input_value) | `qwen_omni_tts_voice_design(variables_get($i2s_spk), text("value"), text("value"))` | qwen_tts_voice_design_request( |
 | `qwen_omni_omni_voice_chat` | Statement | MIC_VAR(field_variable), SPK_VAR(field_variable), DURATION(input_value), MODEL(dropdown), VOICE(dropdown), BEEP(field_checkbox), PROMPT(input_value) | `qwen_omni_omni_voice_chat(variables_get($i2s_mic), variables_get($i2s_spk), math_number(3), qwen3.5-omni-plus, Tina, TRUE, text("value"))` | qwen_omni_voice_chat_request_dual_i2s( |
@@ -82,11 +83,11 @@ arduino_loop()
 1. **Parameter order**: ABS parameters follow `block.json` args order.
 2. **Input values**: use `math_number(n)`, `text("s")`, `logic_boolean(TRUE/FALSE)`, variables, or nested value blocks.
 3. **UNIHIKER K10 built-in audio**: use `qwen_omni_k10_audio_init` once in setup, then select the same `i2s_k10` variable for both microphone and speaker fields in `qwen_omni_omni_voice_chat`. Pins are fixed by the K10 SDK: BCLK `0`, LRCK `38`, MIC DIN `39`, speaker DOUT `45`, MCLK `3`, and amplifier enable `eAmp_Gain`. K10 mode reuses the SDK-installed I2S driver when available instead of reinstalling it, which avoids disturbing camera preview/audio state.
-4. **K10 audio format**: K10 recording is captured from the board I2S bus and converted to 16kHz 16bit mono WAV for Qwen. Qwen mono playback is duplicated to stereo before writing to the built-in speaker.
+4. **K10 audio format**: K10 recording is captured from the board I2S bus in SDK-style 6400-byte stereo chunks, converted to 16kHz 16bit mono WAV for Qwen, and protected with the SDK I2S mutex. Qwen mono playback is duplicated to stereo before writing to the built-in speaker.
 5. **ES8311 microphone**: use `qwen_omni_es8311_mic_init` before recording-only blocks. The I2C address default is decimal `24` (`0x18`) and the gain register default is decimal `36` (`0x24`).
 6. **ES8311 microphone + speaker board**: prefer `qwen_omni_es8311_audio_init` for the board marked Microphone + Audio Amplifier. Use the same I2S variable for microphone and speaker fields in voice-chat/playback blocks, because DI and DO share SCLK/LR/MCK on one ES8311 codec. The tested ESP32 AIOT Basic wiring uses MCK GPIO 46.
 7. **ES8311 PA enable**: leave `PA_EN` at `-1` when the amplifier enable is hardwired. If the carrier board exposes an NS4150/PA enable GPIO, set `PA_EN` to that GPIO so generated code drives it high before playback.
 8. **Prompt tone**: use the single toolbox block `qwen_omni_i2s_prompt_tone` for normal I2S, K10 built-in audio, and ES8311 speaker objects. `qwen_omni_es8311_test_tone` remains only as a hidden legacy-compatible alias for old projects.
-9. **Streaming stability**: audio playback uses a larger stream buffer and longer final-drain timeout. Omni audio requests include a short-answer system instruction to reduce very long cloud responses.
+9. **Streaming stability**: audio playback uses a larger stream buffer, a balanced startup prebuffer, a higher-priority pinned playback task with extra stack, and a longer final-drain timeout. K10 stereo conversion uses static scratch storage to avoid playback-task stack overflow. Omni voice-chat audio requests include a short-answer system instruction and `enable_thinking:false` to reduce very long or text-only cloud responses.
 10. **Vision streaming diagnostics**: image chat requests use SSE headers and `stream_options`; generated code prints HTTP elapsed time and first stream chunk elapsed time. A slow first chunk usually means the cloud model is still processing the image before it can emit text.
-11. **Audio streaming diagnostics**: TTS and omni audio streams print the number of audio chunks, decoded/queued bytes, and played bytes. `audio chunks > 0, queued > 0, played = 0` points to playback/I2S; `audio chunks = 0` points to the API response not containing stream audio data.
+11. **Audio streaming diagnostics**: TTS and omni audio streams print the number of audio chunks, decoded/queued bytes, played bytes, and playback underruns. `audio chunks > 0, queued > 0, played = 0` points to playback/I2S; high `underruns` points to cloud/network audio chunks arriving slower than real-time playback. K10 voice chat also prints expected vs captured PCM bytes; 3 seconds at 16kHz mono should be close to 96000 bytes.


### PR DESCRIPTION
## Summary
- Optimizes K10 multimodal voice playback in `@aily-project/lib-qwen-omni`.
- Adjusts streaming playback buffering, chunk size, task priority/stack, and underrun diagnostics.
- Protects K10 I2S recording/playback with the SDK mutex, uses larger stereo read chunks, and logs expected vs captured PCM bytes.
- Adds `enable_thinking:false` to omni voice requests to reduce long or text-only responses during audio streaming.
- Bumps qwen-omni to 0.0.13 and updates docs.

## Validation
- `node -c qwen-omni/generator.js`
- `node .scripts_git_action/validate-library-compliance.js qwen-omni` -> 131/150 (existing structural warnings remain)