### PR TITLE
feat: add ESP32P4 Robot-Lite Hosted WiFi/BLE library

### DIFF
--- a/esp32p4_robot_lite/block.json
+++ b/esp32p4_robot_lite/block.json
@@ -1,0 +1,62 @@
+[
+  {
+    "type": "esp32p4_robot_lite_begin",
+    "message0": "初始化 Robot-Lite 电源和 C6 Hosted",
+    "previousStatement": null,
+    "nextStatement": null,
+    "colour": "#455A64",
+    "tooltip": "配置 VO1～VO4 电源域，并将 ESP32-C6 Hosted SDIO 切换到 Robot-Lite 引脚",
+    "helpUrl": "https://github.com/ailyProject/aily-blockly-boards/issues/114",
+    "icon": "fa-light fa-microchip"
+  },
+  {
+    "type": "esp32p4_robot_lite_wifi_connect",
+    "message0": "Robot-Lite C6 连接 WiFi 名称 %1 密码 %2",
+    "args0": [
+      {
+        "type": "input_value",
+        "name": "SSID",
+        "check": "String"
+      },
+      {
+        "type": "input_value",
+        "name": "PASSWORD",
+        "check": "String"
+      }
+    ],
+    "inputsInline": false,
+    "previousStatement": null,
+    "nextStatement": null,
+    "colour": "#0288D1",
+    "tooltip": "先配置 Robot-Lite 的 C6 SDIO 引脚，再通过 ESP-Hosted 连接 WiFi",
+    "helpUrl": "https://github.com/ailyProject/aily-blockly-boards/issues/114",
+    "icon": "fa-light fa-wifi"
+  },
+  {
+    "type": "esp32p4_robot_lite_wifi_connected",
+    "message0": "Robot-Lite C6 WiFi 已连接",
+    "output": "Boolean",
+    "colour": "#0288D1",
+    "tooltip": "返回 ESP32-C6 Hosted WiFi 是否已经连接",
+    "helpUrl": "https://github.com/ailyProject/aily-blockly-boards/issues/114",
+    "icon": "fa-light fa-signal"
+  },
+  {
+    "type": "esp32p4_robot_lite_ble_init",
+    "message0": "初始化 Robot-Lite C6 BLE 名称 %1",
+    "args0": [
+      {
+        "type": "input_value",
+        "name": "NAME",
+        "check": "String"
+      }
+    ],
+    "inputsInline": true,
+    "previousStatement": null,
+    "nextStatement": null,
+    "colour": "#3949AB",
+    "tooltip": "先配置 Robot-Lite 的 C6 SDIO 引脚，再初始化 Hosted BLE",
+    "helpUrl": "https://github.com/ailyProject/aily-blockly-boards/issues/114",
+    "icon": "fa-brands fa-bluetooth-b"
+  }
+]

--- a/esp32p4_robot_lite/generator.js
+++ b/esp32p4_robot_lite/generator.js
@@ -1,0 +1,81 @@
+'use strict';
+
+Arduino.ensureRobotLiteSupport = function(generator) {
+  generator.addLibrary('robot_lite_ldo', '#include <esp32-hal-ldo.h>');
+  generator.addLibrary('robot_lite_hosted', '#include <esp32-hal-hosted.h>');
+
+  generator.addObject('robot_lite_state', `static ldo_channel_handle_t g_robot_lite_vo1 = nullptr;
+static ldo_channel_handle_t g_robot_lite_vo2 = nullptr;
+static ldo_channel_handle_t g_robot_lite_vo3 = nullptr;
+static ldo_channel_handle_t g_robot_lite_vo4 = nullptr;
+static bool g_robot_lite_ready = false;`);
+
+  generator.addFunction('robot_lite_acquire_ldo', `static bool ailyRobotLiteAcquireLdo(uint8_t channel, int voltageMv, ldo_channel_handle_t &handle) {
+  if (handle != nullptr) {
+    return true;
+  }
+  return ldoAcquireChannel(channel, voltageMv, false, &handle) == ESP_OK;
+}`);
+
+  generator.addFunction('robot_lite_begin', `static bool ailyRobotLiteBegin() {
+  if (g_robot_lite_ready) {
+    return true;
+  }
+
+  if (!ailyRobotLiteAcquireLdo(1, 3300, g_robot_lite_vo1) ||
+      !ailyRobotLiteAcquireLdo(2, 1800, g_robot_lite_vo2) ||
+      !ailyRobotLiteAcquireLdo(3, 2500, g_robot_lite_vo3)) {
+    return false;
+  }
+
+  if (g_robot_lite_vo4 == nullptr) {
+    ldoDriverClaimChannel(4, "ESP32P4 Robot-Lite");
+    if (!ailyRobotLiteAcquireLdo(4, 3300, g_robot_lite_vo4)) {
+      ldoDriverReleaseChannel(4);
+      return false;
+    }
+  }
+
+  if (!hostedSetPins(47, 48, 46, 45, 44, 43, 42)) {
+    return false;
+  }
+
+  g_robot_lite_ready = true;
+  return true;
+}`);
+
+  generator.addSetupBegin('robot_lite_setup', '  ailyRobotLiteBegin();');
+};
+
+Arduino.forBlock['esp32p4_robot_lite_begin'] = function(block, generator) {
+  Arduino.ensureRobotLiteSupport(generator);
+  return '';
+};
+
+Arduino.forBlock['esp32p4_robot_lite_wifi_connect'] = function(block, generator) {
+  Arduino.ensureRobotLiteSupport(generator);
+  generator.addLibrary('robot_lite_wifi', '#include <WiFi.h>');
+  const ssid = generator.valueToCode(block, 'SSID', generator.ORDER_ATOMIC) || '""';
+  const password = generator.valueToCode(block, 'PASSWORD', generator.ORDER_ATOMIC) || '""';
+  return `if (ailyRobotLiteBegin()) {
+  WiFi.mode(WIFI_STA);
+  WiFi.begin(String(${ssid}).c_str(), String(${password}).c_str());
+}
+`;
+};
+
+Arduino.forBlock['esp32p4_robot_lite_wifi_connected'] = function(block, generator) {
+  Arduino.ensureRobotLiteSupport(generator);
+  generator.addLibrary('robot_lite_wifi', '#include <WiFi.h>');
+  return ['WiFi.status() == WL_CONNECTED', generator.ORDER_EQUALITY];
+};
+
+Arduino.forBlock['esp32p4_robot_lite_ble_init'] = function(block, generator) {
+  Arduino.ensureRobotLiteSupport(generator);
+  generator.addLibrary('robot_lite_ble', '#include <BLEDevice.h>');
+  const name = generator.valueToCode(block, 'NAME', generator.ORDER_ATOMIC) || '"Robot-Lite"';
+  return `if (ailyRobotLiteBegin()) {
+  BLEDevice::init(String(${name}).c_str());
+}
+`;
+};

--- a/esp32p4_robot_lite/i18n/ar.json
+++ b/esp32p4_robot_lite/i18n/ar.json
@@ -1,0 +1,7 @@
+{
+  "toolbox_name": "Robot-Lite",
+  "esp32p4_robot_lite_begin": {"message0": "تهيئة طاقة Robot-Lite و C6 Hosted", "tooltip": "تهيئة VO1–VO4 وأطراف ESP32-C6 Hosted SDIO"},
+  "esp32p4_robot_lite_wifi_connect": {"message0": "اتصال Robot-Lite C6 بالشبكة SSID %1 كلمة المرور %2", "tooltip": "تهيئة C6 SDIO قبل اتصال Hosted WiFi"},
+  "esp32p4_robot_lite_wifi_connected": {"message0": "Robot-Lite C6 WiFi متصل", "tooltip": "إرجاع حالة اتصال Hosted WiFi"},
+  "esp32p4_robot_lite_ble_init": {"message0": "تهيئة Robot-Lite C6 BLE الاسم %1", "tooltip": "تهيئة C6 SDIO قبل Hosted BLE"}
+}

--- a/esp32p4_robot_lite/i18n/de.json
+++ b/esp32p4_robot_lite/i18n/de.json
@@ -1,0 +1,7 @@
+{
+  "toolbox_name": "Robot-Lite",
+  "esp32p4_robot_lite_begin": {"message0": "Robot-Lite-Stromversorgung und C6 Hosted initialisieren", "tooltip": "VO1–VO4 und die ESP32-C6-Hosted-SDIO-Pins konfigurieren"},
+  "esp32p4_robot_lite_wifi_connect": {"message0": "Robot-Lite C6 mit WiFi verbinden SSID %1 Passwort %2", "tooltip": "Robot-Lite C6 SDIO vor der WiFi-Verbindung konfigurieren"},
+  "esp32p4_robot_lite_wifi_connected": {"message0": "Robot-Lite C6 WiFi ist verbunden", "tooltip": "Hosted-WiFi-Verbindungsstatus zurückgeben"},
+  "esp32p4_robot_lite_ble_init": {"message0": "Robot-Lite C6 BLE initialisieren Name %1", "tooltip": "Robot-Lite C6 SDIO vor Hosted BLE konfigurieren"}
+}

--- a/esp32p4_robot_lite/i18n/en.json
+++ b/esp32p4_robot_lite/i18n/en.json
@@ -1,0 +1,7 @@
+{
+  "toolbox_name": "Robot-Lite",
+  "esp32p4_robot_lite_begin": {"message0": "initialize Robot-Lite power and C6 Hosted", "tooltip": "Configure VO1–VO4 and switch ESP32-C6 Hosted SDIO to the Robot-Lite pins"},
+  "esp32p4_robot_lite_wifi_connect": {"message0": "Robot-Lite C6 connect WiFi SSID %1 password %2", "tooltip": "Configure Robot-Lite C6 SDIO before connecting through ESP-Hosted WiFi"},
+  "esp32p4_robot_lite_wifi_connected": {"message0": "Robot-Lite C6 WiFi is connected", "tooltip": "Return whether ESP32-C6 Hosted WiFi is connected"},
+  "esp32p4_robot_lite_ble_init": {"message0": "initialize Robot-Lite C6 BLE name %1", "tooltip": "Configure Robot-Lite C6 SDIO before initializing Hosted BLE"}
+}

--- a/esp32p4_robot_lite/i18n/es.json
+++ b/esp32p4_robot_lite/i18n/es.json
@@ -1,0 +1,7 @@
+{
+  "toolbox_name": "Robot-Lite",
+  "esp32p4_robot_lite_begin": {"message0": "inicializar energía Robot-Lite y C6 Hosted", "tooltip": "Configurar VO1–VO4 y los pines SDIO Hosted del ESP32-C6"},
+  "esp32p4_robot_lite_wifi_connect": {"message0": "Robot-Lite C6 conectar WiFi SSID %1 contraseña %2", "tooltip": "Configurar SDIO C6 de Robot-Lite antes de conectar WiFi"},
+  "esp32p4_robot_lite_wifi_connected": {"message0": "WiFi Robot-Lite C6 conectado", "tooltip": "Devolver el estado de conexión de Hosted WiFi"},
+  "esp32p4_robot_lite_ble_init": {"message0": "inicializar BLE Robot-Lite C6 nombre %1", "tooltip": "Configurar SDIO C6 de Robot-Lite antes de Hosted BLE"}
+}

--- a/esp32p4_robot_lite/i18n/fr.json
+++ b/esp32p4_robot_lite/i18n/fr.json
@@ -1,0 +1,7 @@
+{
+  "toolbox_name": "Robot-Lite",
+  "esp32p4_robot_lite_begin": {"message0": "initialiser l’alimentation Robot-Lite et C6 Hosted", "tooltip": "Configurer VO1–VO4 et les broches SDIO Hosted de l’ESP32-C6"},
+  "esp32p4_robot_lite_wifi_connect": {"message0": "Robot-Lite C6 connecter le WiFi SSID %1 mot de passe %2", "tooltip": "Configurer le SDIO C6 Robot-Lite avant la connexion WiFi"},
+  "esp32p4_robot_lite_wifi_connected": {"message0": "WiFi Robot-Lite C6 connecté", "tooltip": "Renvoyer l’état de la connexion WiFi Hosted"},
+  "esp32p4_robot_lite_ble_init": {"message0": "initialiser le BLE Robot-Lite C6 nom %1", "tooltip": "Configurer le SDIO C6 Robot-Lite avant Hosted BLE"}
+}

--- a/esp32p4_robot_lite/i18n/ja.json
+++ b/esp32p4_robot_lite/i18n/ja.json
@@ -1,0 +1,7 @@
+{
+  "toolbox_name": "Robot-Lite",
+  "esp32p4_robot_lite_begin": {"message0": "Robot-Lite の電源と C6 Hosted を初期化", "tooltip": "VO1～VO4 と ESP32-C6 Hosted SDIO ピンを設定します"},
+  "esp32p4_robot_lite_wifi_connect": {"message0": "Robot-Lite C6 WiFi に接続 SSID %1 パスワード %2", "tooltip": "Robot-Lite C6 SDIO を設定してから WiFi に接続します"},
+  "esp32p4_robot_lite_wifi_connected": {"message0": "Robot-Lite C6 WiFi 接続済み", "tooltip": "Hosted WiFi の接続状態を返します"},
+  "esp32p4_robot_lite_ble_init": {"message0": "Robot-Lite C6 BLE を初期化 名前 %1", "tooltip": "Robot-Lite C6 SDIO を設定してから Hosted BLE を初期化します"}
+}

--- a/esp32p4_robot_lite/i18n/ko.json
+++ b/esp32p4_robot_lite/i18n/ko.json
@@ -1,0 +1,7 @@
+{
+  "toolbox_name": "Robot-Lite",
+  "esp32p4_robot_lite_begin": {"message0": "Robot-Lite 전원 및 C6 Hosted 초기화", "tooltip": "VO1~VO4와 ESP32-C6 Hosted SDIO 핀을 설정합니다"},
+  "esp32p4_robot_lite_wifi_connect": {"message0": "Robot-Lite C6 WiFi 연결 SSID %1 비밀번호 %2", "tooltip": "Robot-Lite C6 SDIO를 설정한 후 WiFi에 연결합니다"},
+  "esp32p4_robot_lite_wifi_connected": {"message0": "Robot-Lite C6 WiFi 연결됨", "tooltip": "Hosted WiFi 연결 상태를 반환합니다"},
+  "esp32p4_robot_lite_ble_init": {"message0": "Robot-Lite C6 BLE 초기화 이름 %1", "tooltip": "Robot-Lite C6 SDIO를 설정한 후 Hosted BLE를 초기화합니다"}
+}

--- a/esp32p4_robot_lite/i18n/pt.json
+++ b/esp32p4_robot_lite/i18n/pt.json
@@ -1,0 +1,7 @@
+{
+  "toolbox_name": "Robot-Lite",
+  "esp32p4_robot_lite_begin": {"message0": "inicializar energia Robot-Lite e C6 Hosted", "tooltip": "Configurar VO1–VO4 e os pinos SDIO Hosted do ESP32-C6"},
+  "esp32p4_robot_lite_wifi_connect": {"message0": "Robot-Lite C6 conectar WiFi SSID %1 senha %2", "tooltip": "Configurar o SDIO C6 do Robot-Lite antes de conectar ao WiFi"},
+  "esp32p4_robot_lite_wifi_connected": {"message0": "WiFi Robot-Lite C6 conectado", "tooltip": "Retornar o estado da conexão Hosted WiFi"},
+  "esp32p4_robot_lite_ble_init": {"message0": "inicializar BLE Robot-Lite C6 nome %1", "tooltip": "Configurar o SDIO C6 do Robot-Lite antes do Hosted BLE"}
+}

--- a/esp32p4_robot_lite/i18n/ru.json
+++ b/esp32p4_robot_lite/i18n/ru.json
@@ -1,0 +1,7 @@
+{
+  "toolbox_name": "Robot-Lite",
+  "esp32p4_robot_lite_begin": {"message0": "инициализировать питание Robot-Lite и C6 Hosted", "tooltip": "Настроить VO1–VO4 и выводы ESP32-C6 Hosted SDIO"},
+  "esp32p4_robot_lite_wifi_connect": {"message0": "Robot-Lite C6 подключить WiFi SSID %1 пароль %2", "tooltip": "Настроить C6 SDIO перед подключением Hosted WiFi"},
+  "esp32p4_robot_lite_wifi_connected": {"message0": "Robot-Lite C6 WiFi подключён", "tooltip": "Вернуть состояние подключения Hosted WiFi"},
+  "esp32p4_robot_lite_ble_init": {"message0": "инициализировать Robot-Lite C6 BLE имя %1", "tooltip": "Настроить C6 SDIO перед инициализацией Hosted BLE"}
+}

--- a/esp32p4_robot_lite/i18n/zh_cn.json
+++ b/esp32p4_robot_lite/i18n/zh_cn.json
@@ -1,0 +1,7 @@
+{
+  "toolbox_name": "Robot-Lite",
+  "esp32p4_robot_lite_begin": {"message0": "初始化 Robot-Lite 电源和 C6 Hosted", "tooltip": "配置 VO1～VO4 电源域，并将 ESP32-C6 Hosted SDIO 切换到 Robot-Lite 引脚"},
+  "esp32p4_robot_lite_wifi_connect": {"message0": "Robot-Lite C6 连接 WiFi 名称 %1 密码 %2", "tooltip": "先配置 Robot-Lite 的 C6 SDIO 引脚，再通过 ESP-Hosted 连接 WiFi"},
+  "esp32p4_robot_lite_wifi_connected": {"message0": "Robot-Lite C6 WiFi 已连接", "tooltip": "返回 ESP32-C6 Hosted WiFi 是否已经连接"},
+  "esp32p4_robot_lite_ble_init": {"message0": "初始化 Robot-Lite C6 BLE 名称 %1", "tooltip": "先配置 Robot-Lite 的 C6 SDIO 引脚，再初始化 Hosted BLE"}
+}

--- a/esp32p4_robot_lite/i18n/zh_hk.json
+++ b/esp32p4_robot_lite/i18n/zh_hk.json
@@ -1,0 +1,7 @@
+{
+  "toolbox_name": "Robot-Lite",
+  "esp32p4_robot_lite_begin": {"message0": "初始化 Robot-Lite 電源和 C6 Hosted", "tooltip": "設定 VO1～VO4 電源域，並將 ESP32-C6 Hosted SDIO 切換到 Robot-Lite 引腳"},
+  "esp32p4_robot_lite_wifi_connect": {"message0": "Robot-Lite C6 連接 WiFi 名稱 %1 密碼 %2", "tooltip": "先設定 Robot-Lite 的 C6 SDIO 引腳，再透過 ESP-Hosted 連接 WiFi"},
+  "esp32p4_robot_lite_wifi_connected": {"message0": "Robot-Lite C6 WiFi 已連接", "tooltip": "傳回 ESP32-C6 Hosted WiFi 是否已連接"},
+  "esp32p4_robot_lite_ble_init": {"message0": "初始化 Robot-Lite C6 BLE 名稱 %1", "tooltip": "先設定 Robot-Lite 的 C6 SDIO 引腳，再初始化 Hosted BLE"}
+}

--- a/esp32p4_robot_lite/package.json
+++ b/esp32p4_robot_lite/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@aily-project/lib-esp32p4-robot-lite",
+  "nickname": "ESP32P4 Robot-Lite",
+  "nickname_zh_cn": "ESP32P4 Robot-Lite",
+  "nickname_en": "ESP32P4 Robot-Lite",
+  "nickname_zh_hk": "ESP32P4 Robot-Lite",
+  "nickname_ja": "ESP32P4 Robot-Lite",
+  "nickname_ko": "ESP32P4 Robot-Lite",
+  "nickname_de": "ESP32P4 Robot-Lite",
+  "nickname_fr": "ESP32P4 Robot-Lite",
+  "nickname_es": "ESP32P4 Robot-Lite",
+  "nickname_pt": "ESP32P4 Robot-Lite",
+  "nickname_ru": "ESP32P4 Robot-Lite",
+  "nickname_ar": "ESP32P4 Robot-Lite",
+  "author": "ailyProject",
+  "description": "为 ESP32P4 Robot-Lite V1.1 配置电源域和 ESP32-C6 Hosted WiFi/BLE",
+  "description_zh_cn": "为 ESP32P4 Robot-Lite V1.1 配置电源域和 ESP32-C6 Hosted WiFi/BLE",
+  "description_en": "Configures power domains and ESP32-C6 Hosted WiFi/BLE for ESP32P4 Robot-Lite V1.1",
+  "version": "0.0.1",
+  "compatibility": {
+    "core": [
+      "esp32:esp32:esp32p4"
+    ],
+    "voltage": [
+      3.3
+    ]
+  },
+  "keywords": [
+    "aily",
+    "blockly",
+    "esp32p4",
+    "robot-lite",
+    "esp-hosted",
+    "esp32-c6",
+    "wifi",
+    "ble",
+    "ldo"
+  ],
+  "scripts": {},
+  "dependencies": {},
+  "devDependencies": {},
+  "tested": false,
+  "tester": "",
+  "url": "https://github.com/ailyProject/aily-blockly-boards/issues/114",
+  "license": "MIT",
+  "tags": [
+    "wireless",
+    "communication"
+  ]
+}

--- a/esp32p4_robot_lite/readme.md
+++ b/esp32p4_robot_lite/readme.md
@@ -1,0 +1,24 @@
+# ESP32P4 Robot-Lite
+
+## Library Info
+
+| Field | Value |
+| --- | --- |
+| Package | `@aily-project/lib-esp32p4-robot-lite` |
+| Version | 0.0.1 |
+| License | MIT |
+| Core | Arduino-ESP32 3.3.11 |
+
+## Supported Boards
+
+ESP32P4 Robot-Lite V1.1 using `esp32:esp32:esp32p4`.
+
+## Description
+
+Configures VO1–VO4 at 3.3 V, 1.8 V, 2.5 V and 3.3 V. It maps the ESP32-C6 Hosted SDIO pins to CLK 47, CMD 48, D0 46, D1 45, D2 44, D3 43 and RESET 42 before WiFi or BLE starts.
+
+GPIO41 is reserved but not driven without a verified schematic. Compile validation does not confirm C6 firmware, SDIO pull-ups, power timing or radio operation. ES7243E and acoustic echo cancellation are not included.
+
+## Quick Start
+
+Add the initialization block before WiFi/BLE use, or use the library's WiFi/BLE blocks, which add initialization automatically.

--- a/esp32p4_robot_lite/readme_ai.md
+++ b/esp32p4_robot_lite/readme_ai.md
@@ -1,0 +1,24 @@
+# ESP32P4 Robot-Lite
+
+## Library Info
+
+| Field | Value |
+| --- | --- |
+| Package | `@aily-project/lib-esp32p4-robot-lite` |
+| Version | 0.0.1 |
+| Core | `esp32:esp32:esp32p4` |
+
+## Block Definitions
+
+| Block Type | Connection | Parameters (args0 order) | ABS Format | Generated Code |
+|------------|------------|--------------------------|------------|----------------|
+| `esp32p4_robot_lite_begin` | Statement | None | `esp32p4_robot_lite_begin()` | Acquire VO1–VO4 and configure Hosted SDIO. |
+| `esp32p4_robot_lite_wifi_connect` | Statement | `SSID(input_value)`, `PASSWORD(input_value)` | `esp32p4_robot_lite_wifi_connect(text("ssid"), text("password"))` | Initialize board support and call `WiFi.begin()`. |
+| `esp32p4_robot_lite_wifi_connected` | Value Boolean | None | `esp32p4_robot_lite_wifi_connected()` | Compare `WiFi.status()` with `WL_CONNECTED`. |
+| `esp32p4_robot_lite_ble_init` | Statement | `NAME(input_value)` | `esp32p4_robot_lite_ble_init(text("Robot-Lite"))` | Initialize board support and call `BLEDevice::init()`. |
+
+## Generated board configuration
+
+`hostedSetPins(47, 48, 46, 45, 44, 43, 42)` maps CLK, CMD, D0, D1, D2, D3 and RESET respectively. LDO channels are held for the lifetime of the sketch at 3300, 1800, 2500 and 3300 mV.
+
+The target must be `esp32:esp32:esp32p4` with Arduino-ESP32 3.3.11 or later API compatibility.

--- a/esp32p4_robot_lite/toolbox.json
+++ b/esp32p4_robot_lite/toolbox.json
@@ -1,0 +1,51 @@
+{
+  "kind": "category",
+  "name": "Robot-Lite",
+  "icon": "fa-light fa-robot",
+  "contents": [
+    {
+      "kind": "block",
+      "type": "esp32p4_robot_lite_begin"
+    },
+    {
+      "kind": "block",
+      "type": "esp32p4_robot_lite_wifi_connect",
+      "inputs": {
+        "SSID": {
+          "shadow": {
+            "type": "text",
+            "fields": {
+              "TEXT": "WiFi name"
+            }
+          }
+        },
+        "PASSWORD": {
+          "shadow": {
+            "type": "text",
+            "fields": {
+              "TEXT": "WiFi password"
+            }
+          }
+        }
+      }
+    },
+    {
+      "kind": "block",
+      "type": "esp32p4_robot_lite_wifi_connected"
+    },
+    {
+      "kind": "block",
+      "type": "esp32p4_robot_lite_ble_init",
+      "inputs": {
+        "NAME": {
+          "shadow": {
+            "type": "text",
+            "fields": {
+              "TEXT": "Robot-Lite"
+            }
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Related issue and routing

- Board request: https://github.com/ailyProject/aily-blockly-boards/issues/114
- This PR is in `aily-blockly-libraries` because it adds the board-specific Blockly/API layer for the ESP32-C6 Hosted radio. The board package itself is submitted separately to `aily-blockly-boards`.
- Board package: https://github.com/ailyProject/aily-blockly-boards/pull/117

## Summary

Add `@aily-project/lib-esp32p4-robot-lite` 0.0.1 for ESP32P4 Robot-Lite V1.1. The library uses the generic Arduino-ESP32 P4 target and configures the board-specific power domains and ESP32-C6 Hosted SDIO mapping before Wi-Fi or BLE starts.

## Implementation

- Hold ESP32-P4 LDO channels at VO1 3.3 V, VO2 1.8 V, VO3 2.5 V and VO4 3.3 V.
- Call `hostedSetPins(47, 48, 46, 45, 44, 43, 42)` for CLK, CMD, D0, D1, D2, D3 and C6 reset.
- Add initialization, Wi-Fi connect/status and BLE initialization blocks.
- Initialize the board support automatically when a Wi-Fi or BLE block is used.
- Add toolbox metadata, 11 locales and human/ABS documentation.

GPIO41 is reserved as the C6 boot-related pin but is not driven because its required level and timing are not verified by a schematic.

## Version

- New library: `0.0.1`

## Toolchain and validation

- Arduino CLI: `C:\Program Files\Arduino CLI\arduino-cli.exe` 1.5.1
- Core: `esp32:esp32` 3.3.11-cn
- FQBN: `esp32:esp32:esp32p4`
- Repository compliance: 88%, exit 0; README, JSON, block/toolbox mappings and generator syntax passed.
- Clean native compile: LDO + Hosted initialization passed.
- Clean native compile: dedicated Wi-Fi path passed.
- Clean native compile: dedicated BLE path passed.
- Clean compile of code produced by the Blockly generator harness passed: 867346 bytes flash, 29268 bytes global data.
- `git diff --check` passed.

### GitHub Actions status

The PR's `validate-libraries` job is currently blocked by the repository-wide i18n baseline. Because this PR adds locale files, the workflow runs `npm run i18n:check` for the entire repository and reports 253 pre-existing issues in unrelated libraries, including missing locale directories in `chipIntelli_ASR`/`chipIntelli_Audio` and missing `nofrendo` keys. The job log did not report an `esp32p4_robot_lite` locale error. Fixing the unrelated baseline is intentionally outside issue #114; the targeted library compliance command above passes.

## Compatibility, evidence and risk

- No third-party implementation was copied. The library calls APIs provided by Arduino-ESP32 3.3.11 (`esp32-hal-ldo.h` and `esp32-hal-hosted.h`) and is licensed MIT.
- Compilation verifies API and build compatibility only. No matching Robot-Lite V1.1 board was detected, so upload, C6 firmware/SDIO behavior, power timing and radio operation are not hardware-tested.
- ES7243E initialization and acoustic echo cancellation are outside this library and are not claimed as supported.
- Administrator should confirm the board's GPIO41 boot behavior and perform target-hardware radio testing before marking support stable.

## Merge dependency

The board package PR should merge/publish this library first or coordinate both releases so its template dependency can resolve.
