### PR TITLE
fix: restore legacy TFT_eSPI setup projects

### DIFF
--- a/TFT_eSPI/generator.js
+++ b/TFT_eSPI/generator.js
@@ -36,6 +36,69 @@ function cleanValue(value) {
   return value;
 }
 
+// Versions <= 2.5.46 stored these setup values as value inputs. Since 2.5.47
+// they are inline fields, but published projects can still contain the old
+// connections. Keep hidden compatibility inputs so Blockly can restore them.
+var tftEspiLegacySetupInputNames = [
+  'WIDTH',
+  'HEIGHT',
+  'MISO',
+  'MOSI',
+  'SCLK',
+  'CS',
+  'DC',
+  'RST',
+  'BL'
+];
+
+function ensureTftEspiLegacySetupInputs(block) {
+  tftEspiLegacySetupInputNames.forEach(name => {
+    let input = block.getInput(name);
+    if (!input) {
+      input = block.appendValueInput(name).setCheck('Number');
+    }
+
+    if (block.rendered) {
+      input.setVisible(false);
+    }
+  });
+}
+
+function migrateTftEspiLegacyNumberInputs(block) {
+  tftEspiLegacySetupInputNames.forEach(name => {
+    const input = block.getInput(name);
+    const targetBlock = input && input.connection && input.connection.targetBlock();
+    const field = block.getField(name);
+    if (!targetBlock || !field || targetBlock.type !== 'math_number' || !targetBlock.isShadow()) {
+      return;
+    }
+
+    const value = targetBlock.getFieldValue('NUM');
+    if (value !== null && value !== undefined) {
+      field.setValue(String(value));
+      targetBlock.dispose(false);
+      if (typeof input.connection.setShadowState === 'function') {
+        input.connection.setShadowState(null);
+      }
+    }
+  });
+}
+
+function getTftEspiSetupValue(block, generator, name, fallback) {
+  const input = block.getInput(name);
+  if (input && input.connection && input.connection.targetConnection) {
+    const legacyValue = generator.valueToCode(block, name, generator.ORDER_ATOMIC);
+    if (legacyValue) {
+      return cleanValue(legacyValue);
+    }
+  }
+
+  const fieldValue = block.getFieldValue(name);
+  return fieldValue === null || fieldValue === undefined || fieldValue === ''
+    ? fallback
+    : fieldValue;
+}
+
 // Apply the board's built-in display settings once, while keeping later manual edits.
 function applyBoardDisplayConfig(block) {
   const config = typeof window !== 'undefined' && window['boardConfig']
@@ -90,9 +153,12 @@ if (Blockly.Extensions.isRegistered('tftespi_board_display_config')) {
 
 Blockly.Extensions.register('tftespi_board_display_config', function() {
   const block = this;
+  ensureTftEspiLegacySetupInputs(block);
   let retries = 0;
   const updateConfig = () => {
     if (!block.workspace) return;
+    ensureTftEspiLegacySetupInputs(block);
+    migrateTftEspiLegacyNumberInputs(block);
     if (!applyBoardDisplayConfig(block) && retries++ < 3) {
       setTimeout(updateConfig, 0);
       return;
@@ -254,15 +320,15 @@ Arduino.forBlock['tftespi_setup'] = function(block, generator) {
   const varName = block.getFieldValue('VAR') || 'tft';
   const model = block.getFieldValue('MODEL') || 'ILI9341_DRIVER';
   const frequency = block.getFieldValue('FREQUENCY') || '40000000';
-  const width = block.getFieldValue('WIDTH') || '240';
-  const height = block.getFieldValue('HEIGHT') || '320';
-  const miso = block.getFieldValue('MISO') || '-1';
-  const mosi = block.getFieldValue('MOSI') || '-1';
-  const sclk = block.getFieldValue('SCLK') || '-1';
-  const cs = block.getFieldValue('CS') || '-1';
-  const dc = block.getFieldValue('DC') || '-1';
-  const rst = block.getFieldValue('RST') || '-1';
-  const bl = block.getFieldValue('BL') || '-1';
+  const width = getTftEspiSetupValue(block, generator, 'WIDTH', '240');
+  const height = getTftEspiSetupValue(block, generator, 'HEIGHT', '320');
+  const miso = getTftEspiSetupValue(block, generator, 'MISO', '-1');
+  const mosi = getTftEspiSetupValue(block, generator, 'MOSI', '-1');
+  const sclk = getTftEspiSetupValue(block, generator, 'SCLK', '-1');
+  const cs = getTftEspiSetupValue(block, generator, 'CS', '-1');
+  const dc = getTftEspiSetupValue(block, generator, 'DC', '-1');
+  const rst = getTftEspiSetupValue(block, generator, 'RST', '-1');
+  const bl = getTftEspiSetupValue(block, generator, 'BL', '-1');
   const blLevel = block.getFieldValue('BL_LEVEL') || 'HIGH';
   const colorMode = block.getFieldValue('COLOR_MODE') || 'TFT_RGB';
   // const rotation = block.getFieldValue('ROTATION') || '0';

--- a/TFT_eSPI/package.json
+++ b/TFT_eSPI/package.json
@@ -25,7 +25,7 @@
   "description_ru": "TFT_eSPI — библиотека Arduino, графика и библиотека шрифтов, поддерживающая несколько TFT-дисплеев.",
   "description_ar": "TFT_eSPI - مكتبة Arduino ومكتبة الرسومات والخطوط التي تدعم شاشات TFT المتعددة",
   "author": "ailyProject",
-  "version": "2.5.50",
+  "version": "2.5.51",
   "compatibility": {
     "core": [
       "esp32:esp32",


### PR DESCRIPTION
## 分流依据

- 关联 Issue：Fixes #490
- 重复/补充证据：#492
- 分类：库 Bug；问题由 `@aily-project/lib-tft-espi` 的积木结构升级造成，可仅在 aily-blockly-libraries 内完整修复。

## 问题摘要

项目广场公开项目 ID 275（“LVGL&TFT_eSPI 中文显示”）使用 `@aily-project/lib-tft-espi: ^2.5.43`。TFT_eSPI 2.5.47 将 `tftespi_setup` 的 `WIDTH`、`HEIGHT`、`MISO`、`MOSI`、`SCLK`、`CS`、`DC`、`RST`、`BL` 从值连接改成了内联字段，但没有保留旧项目反序列化所需的连接。安装当前 2.5.50 后，Blockly 因缺少 `WIDTH` 连接而终止加载。

## 实现

- 为 2.5.46 及以前的 9 个 setup 参数保留隐藏兼容连接。
- 旧数值影子块加载后迁移到当前字段，并清除旧 shadow state，避免重新保存时继续携带旧结构。
- 旧项目若使用非影子表达式，则保留连接并继续按原值生成宏。
- 当前字段格式保持不变。
- 版本：`@aily-project/lib-tft-espi` 2.5.50 → 2.5.51。

## 验证

- 未修复基线：使用项目广场 ID 275 的原始 `project.abi` 稳定复现 `missing a(n) WIDTH connection`。
- 修复后：同一 ABI 成功反序列化，9 个旧值恢复为 `172/320/-1/10/12/13/11/14/3`。
- 迁移后重新保存不会写出空旧连接。
- 非影子旧表达式仍参与代码生成；当前 2.5.50 字段格式仍能加载。
- setup 代码及 `TFT_WIDTH`、`TFT_HEIGHT`、引脚宏生成值保持一致。
- `node .scripts_git_action/validate-library-compliance.js TFT_eSPI`：98%，退出码 0；仅有仓库原有 README 大小及 Serial 建议。
- `node --check TFT_eSPI/generator.js`、JSON 解析、`git diff --check`：通过。

## 兼容性与风险

- 仅修改 TFT_eSPI 的 Blockly 反序列化兼容层和补丁版本，不修改 Arduino 源码、底层依赖或主程序。
- 本问题属于项目文件加载兼容性，不涉及上传或硬件行为；未进行硬件实测。
- 合并并发布 2.5.51 后，使用 `^2.5.43` 的公开项目可在重新安装依赖时获得兼容修复。

待管理员审核并发布补丁版本。