### PR TITLE
fix(core-serial): release UART2 persistence as 0.0.2

### DIFF
--- a/core-serial/generator.test.js
+++ b/core-serial/generator.test.js
@@ -1,0 +1,101 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const extensions = new Map();
+let timeoutCount = 0;
+const mainWorkspace = {
+  addChangeListener() {}
+};
+
+function FieldDropdown() {}
+FieldDropdown.prototype.doClassValidation_ = function (value) {
+  return value;
+};
+
+const Blockly = {
+  Field: {},
+  FieldDropdown,
+  Events: { FINISHED_LOADING: 'finished_loading' },
+  Extensions: {
+    isRegistered(name) {
+      return extensions.has(name);
+    },
+    unregister(name) {
+      extensions.delete(name);
+    },
+    register(name, callback) {
+      extensions.set(name, callback);
+    }
+  },
+  getMainWorkspace() {
+    return mainWorkspace;
+  }
+};
+
+const Arduino = {
+  forBlock: Object.create(null),
+  ORDER_ATOMIC: 0,
+  ORDER_FUNCTION_CALL: 1,
+  valueToCode() {
+    return '';
+  }
+};
+
+vm.runInNewContext(
+  fs.readFileSync(path.join(__dirname, 'generator.js'), 'utf8'),
+  {
+    Arduino,
+    Blockly,
+    window: {
+      boardConfig: {
+        uploadParam: 'esptool --chip esp32s3'
+      }
+    },
+    setTimeout() {
+      timeoutCount += 1;
+      return timeoutCount;
+    }
+  },
+  { filename: 'core-serial/generator.js' }
+);
+
+test('ESP32-S3 custom serial exposes UART2 before saved fields are restored', () => {
+  const extension = extensions.get('serial_begin_esp32_custom_extension');
+  assert.equal(typeof extension, 'function');
+  const timeoutCountBeforeExtension = timeoutCount;
+
+  const uartField = {
+    value: 'UART0',
+    menuGenerator_: [['UART0', 'UART0'], ['UART1', 'UART1']],
+    getValue() {
+      return this.value;
+    },
+    setValue(value) {
+      const isValid = this.getOptions().some(([, optionValue]) => optionValue === value);
+      if (isValid) this.value = value;
+    },
+    getOptions() {
+      return this.menuGenerator_;
+    }
+  };
+
+  extension.call({
+    isInFlyout: true,
+    getField(name) {
+      return name === 'UART' ? uartField : null;
+    }
+  });
+
+  assert.equal(timeoutCount, timeoutCountBeforeExtension);
+
+  assert.deepEqual(
+    Array.from(uartField.getOptions(), (option) => Array.from(option)),
+    [['UART0', 'UART0'], ['UART1', 'UART1'], ['UART2', 'UART2']]
+  );
+
+  uartField.setValue('UART2');
+  assert.equal(uartField.getValue(), 'UART2');
+});

--- a/core-serial/package.json
+++ b/core-serial/package.json
@@ -25,7 +25,7 @@
   "description_pt": "Biblioteca de comunicação serial, suporta envio e recebimento de porta serial",
   "description_ru": "Библиотека последовательной связи, поддерживает отправку и получение через последовательный порт.",
   "description_ar": "مكتبة الاتصالات التسلسلية، تدعم إرسال واستقبال المنفذ التسلسلي",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "compatibility": {
     "core": [],
     "voltage": []

--- a/core-serial/readme.md
+++ b/core-serial/readme.md
@@ -7,7 +7,7 @@ Serial communication library, supports serial port sending and receiving
 | Field | Value |
 |-------|-------|
 | Package | @aily-project/lib-core-serial |
-| Version | 0.0.1 |
+| Version | 0.0.2 |
 | Author | ailyProject |
 | Source | N/A |
 | License | Original license |

--- a/core-serial/readme_ai.md
+++ b/core-serial/readme_ai.md
@@ -4,7 +4,7 @@ Serial communication library, supports serial port sending and receiving
 
 ## Library Info
 - **Name**: @aily-project/lib-core-serial
-- **Version**: 0.0.1
+- **Version**: 0.0.2
 
 ## Block Definitions
 


### PR DESCRIPTION
## 关联 Issue

Closes #536

## 分流依据

原 Issue 从 `aily-blockly#661` 原生转移到本仓库。问题来自 `core-serial` 的 ESP32 自定义串口字段恢复：ESP32-S3 工程保存 UART2 后，静态下拉选项曾在动态选项加载前拒绝该值。修复仅涉及 `aily-blockly-libraries`，不需要修改主程序或开发板包。

## 问题与实现

- `main` 已在 `5c1522b36d719e22c95b6f1c615b36b913b70ad4` 同步准备 UART 选项，修复 UART2 保存/恢复。
- 本 PR 将 `@aily-project/lib-core-serial` 从 `0.0.1` 提升到 `0.0.2`，同步更新 `readme.md` 与 `readme_ai.md`，使修复具备可识别的发布版本。
- 新增 Node 回归测试，验证 ESP32-S3 扩展在字段恢复前同步提供 UART0/UART1/UART2，且 flyout 初始化不依赖延迟任务。

## 验证

- `node --test core-serial/generator.test.js`：1/1 通过。
- `npm run validate:changed`：退出码 0；仅 `core-serial`，无新增 ABS 契约问题（现有合规评分 73%，均为本次修改前的建议项）。
- `node .scripts/check-readme-compliance.js core-serial --strict-abs`：通过。
- `node .scripts/check-i18n-compliance.js --library core-serial`：11 个语言文件通过。
- `node --check core-serial/generator.js`、全部相关 JSON 解析、`git diff --check origin/main...HEAD`：通过。
- `C:\Program Files\Arduino CLI\arduino-cli.exe compile --clean --fqbn esp32:esp32:esp32s3 ...\serial2_smoke`：Arduino CLI 1.5.1、ESP32 Core 3.3.11，编译通过；Flash 273289 bytes（20%），RAM 21672 bytes（6%）。草图等价于生成的 `HardwareSerial SerialCustom(2)` 与 `SerialCustom.begin(...)`。

## 兼容性与风险

- 本 PR 不再修改生成器运行逻辑，只补齐版本元数据与回归测试；运行时修复已在 `main`。
- 未检测到明确的 ESP32-S3 目标板（仅 Unknown COM4/COM8），未上传固件，也未进行串口硬件冒烟测试。
- 合并后仍需管理员将该提交纳入 deploy/发布流程，并确认旧项目的库更新入口。